### PR TITLE
added mathjax cdn

### DIFF
--- a/application/views/pages/problems.twig
+++ b/application/views/pages/problems.twig
@@ -15,6 +15,13 @@
 <link rel='stylesheet' type='text/css' href='{{ base_url("assets/snippet/jquery.snippet.css") }}'/>
 <link rel='stylesheet' type='text/css' href='{{ base_url("assets/snippet/themes/github.css") }}'/>
 <script type='text/javascript' src="{{ base_url("assets/snippet/jquery.snippet.js") }}"></script>
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({ tex2jax: { inlineMath: [['$','$'], ["\\(","\\)"]] } });
+</script>
+<script type="text/javascript"
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML">
+</script>
+<meta http-equiv="X-UA-Compatible" CONTENT="IE=EmulateIE7" />
 <script>
 $(document).ready(function(){
 	// Syntax highlighting increases the page's height, and we need to update the scroll-bar


### PR DESCRIPTION
### ___Added mathjax cdn___
Hi.
I added some javascript link and now problem shows latex syntax.
since mathjax is shutting down soon, I wrote the alternative one.
![2017-04-21 2 57 32](https://cloud.githubusercontent.com/assets/9479730/25245122/4e044cb4-263e-11e7-92ab-86f81a994626.png)
