### PR TITLE
Remove the package statement using sed 🔫 

### DIFF
--- a/tester/tester.sh
+++ b/tester/tester.sh
@@ -200,6 +200,7 @@ if [ "$EXT" = "java" ]; then
 	cp ../java.policy java.policy
 	cp $PROBLEMPATH/$UN/$FILENAME.java $MAINFILENAME.java
 	shj_log "Compiling as Java"
+	sed -i "/^package*/d" $MAINFILENAME.java
 	javac $MAINFILENAME.java >/dev/null 2>cerr
 	EXITCODE=$?
 	COMPILE_END_TIME=$(($(date +%s%N)/1000000));


### PR DESCRIPTION
One single line solves the java problem. Students can submit java files containing package statements.

```shell
sed -i "/^package*/d" $MAINFILENAME.java
```
> Attention: Using `sed -i <pattern> <filename>` will overwrite the existing file.

To create a backup file prior to editing, add the backup extension directly after the “-i” option:
```shell
sed -i.bak <pattern> <filename>
```

#86 